### PR TITLE
Update OAuth redirect handling to use window.location.origin

### DIFF
--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -1,0 +1,17 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createSupabaseServerClient } from '@/lib/supabase-server';
+
+export async function GET(request: NextRequest) {
+  const { searchParams, origin } = new URL(request.url);
+  const code = searchParams.get('code');
+
+  if (code) {
+    const supabase = createSupabaseServerClient();
+    const { error } = await supabase.auth.exchangeCodeForSession(code);
+    if (!error) {
+      return NextResponse.redirect(`${origin}/dashboard`);
+    }
+  }
+
+  return NextResponse.redirect(`${origin}/auth?error=oauth`);
+}

--- a/app/auth/page.tsx
+++ b/app/auth/page.tsx
@@ -52,7 +52,8 @@ export default function AuthPage() {
     setError(null);
     const { error } = await supabase.auth.signInWithOAuth({
       provider: 'google',
-      options: { redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/dashboard` },
+      // options: { redirectTo: `${process.env.NEXT_PUBLIC_APP_URL}/auth/callback` },
+      options: { redirectTo: `${window.location.origin}/auth/callback` },
     });
     if (error) setError(error.message);
   };


### PR DESCRIPTION
Change the OAuth redirect URL to utilize `window.location.origin` instead of an environment variable. Introduce a new directory for handling OAuth callbacks and update the redirect path to `/auth/callback`, resulting in a breaking change.